### PR TITLE
[typo] Fix the wrong logo image link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SeaTunnel
 
-<img src="https://seatunnel.apache.org/img/logo.png" alt="seatunnel logo" height="200px" align="right" />
+<img src="https://seatunnel.apache.org/image/logo.png" alt="seatunnel logo" height="200px" align="right" />
 
 [![Backend Workflow](https://github.com/apache/incubator-seatunnel/actions/workflows/backend.yml/badge.svg?branch=dev)](https://github.com/apache/incubator-seatunnel/actions/workflows/backend.yml)
 


### PR DESCRIPTION
Signed-off-by: Al-assad yulin.ying@outlook.com

The logo image in the current README is pointing to an incorrect link:  

<img width="924" alt="iShot2022-01-02 22 40 27" src="https://user-images.githubusercontent.com/22493821/147879444-55549be0-649a-4fb7-99d6-70ade0af20ea.png">

And this is the effect after fixing the link:   

<img width="955" alt="iShot2022-01-02 22 42 13" src="https://user-images.githubusercontent.com/22493821/147879476-d8b19124-2361-4d6d-aa79-cd96e787bd61.png">

