### PR TITLE
Remove useless addAll of list in PropertiesParser

### DIFF
--- a/seatunnel-config/src/main/java/org/apache/seatunnel/config/impl/PropertiesParser.java
+++ b/seatunnel-config/src/main/java/org/apache/seatunnel/config/impl/PropertiesParser.java
@@ -188,8 +188,7 @@ final class PropertiesParser {
          * Make a list of scope paths from longest to shortest, so children go
          * before parents.
          */
-        List<Path> sortedScopePaths = new ArrayList<Path>();
-        sortedScopePaths.addAll(scopePaths);
+        List<Path> sortedScopePaths = new ArrayList<Path>(scopePaths);
         // sort descending by length
         Collections.sort(sortedScopePaths, new Comparator<Path>() {
             @Override


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[SeaTunnel #XXXX] [component] Title of the pull request", where *SeaTunnel #XXXX* should be replaced by the actual issue number.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

We can remove useless `addAll` call of List in PropertiesParser

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] Change does not need document change, or I will submit document change to https://github.com/apache/incubator-seatunnel-website later
