### PR TITLE
Remove useless public keyword for Config interface

### DIFF
--- a/seatunnel-config/src/main/java/org/apache/seatunnel/config/Config.java
+++ b/seatunnel-config/src/main/java/org/apache/seatunnel/config/Config.java
@@ -583,7 +583,7 @@ public interface Config extends ConfigMergeable {
      * @throws ConfigException.Missing   if value is absent or null
      * @throws ConfigException.WrongType if value is not convertible to an Enum
      */
-    public <T extends Enum<T>> T getEnum(Class<T> enumClass, String path);
+    <T extends Enum<T>> T getEnum(Class<T> enumClass, String path);
 
     /**
      * @param path path expression


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[SeaTunnel #XXXX] [component] Title of the pull request", where *SeaTunnel #XXXX* should be replaced by the actual issue number.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

We can remove useless `public` keyword for `Config` interface.

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] Change does not need document change, or I will submit document change to https://github.com/apache/incubator-seatunnel-website later
