### PR TITLE
Fix the wrong link in java doc for CompressionUtils

### DIFF
--- a/seatunnel-core/seatunnel-core-base/src/main/java/org/apache/seatunnel/utils/CompressionUtils.java
+++ b/seatunnel-core/seatunnel-core-base/src/main/java/org/apache/seatunnel/utils/CompressionUtils.java
@@ -92,7 +92,7 @@ public class CompressionUtils {
      *
      * @param inputFile the input .gz file
      * @param outputDir the output directory file.
-     * @return The {@File} with the ungzipped content.
+     * @return The {@link File} with the ungzipped content.
      * @throws IOException           io exception
      * @throws FileNotFoundException file not found exception
      */


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[SeaTunnel #XXXX] [component] Title of the pull request", where *SeaTunnel #XXXX* should be replaced by the actual issue number.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

This PR fixes the wrong link in Java doc for `CompressionUtils`.

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
