### PR TITLE
[Feature][seatunnel-examples] Resolve ConfigParser class conflict between Seatunnel and Flink.

### DIFF
--- a/seatunnel-examples/seatunnel-flink-examples/pom.xml
+++ b/seatunnel-examples/seatunnel-flink-examples/pom.xml
@@ -32,7 +32,8 @@
         <flink.scope>compile</flink.scope>
     </properties>
     <dependencies>
-        <!--Resolve ConfigParser class conflict between Seatunnel and Flink. Native debugging increases flink's default ConfigParser priority.-->
+        <!--Resolve ConfigParser class conflict between Seatunnel and Flink.
+        Native debugging increases flink's default ConfigParser priority.-->
         <dependency>
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>

--- a/seatunnel-examples/seatunnel-flink-examples/pom.xml
+++ b/seatunnel-examples/seatunnel-flink-examples/pom.xml
@@ -32,12 +32,16 @@
         <flink.scope>compile</flink.scope>
     </properties>
     <dependencies>
+        <!--Resolve ConfigParser class conflict between Seatunnel and Flink. Native debugging increases flink's default ConfigParser priority.-->
+        <dependency>
+            <groupId>com.typesafe</groupId>
+            <artifactId>config</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.seatunnel</groupId>
             <artifactId>seatunnel-core-flink</artifactId>
             <version>${parent.version}</version>
         </dependency>
-
         <!--flink-->
         <dependency>
             <groupId>org.apache.flink</groupId>


### PR DESCRIPTION
Resolve ConfigParser class conflict between Seatunnel and Flink.
Native debugging increases flink's default ConfigParser priority.


![image](https://user-images.githubusercontent.com/59079269/148879776-ba646313-f6dd-485f-b89f-d0e2d5470559.png)
The modified：
![image](https://user-images.githubusercontent.com/59079269/148879793-01a558bf-3675-4fff-8c57-9eefc34bbb21.png)

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[SeaTunnel #XXXX] [component] Title of the pull request", where *SeaTunnel #XXXX* should be replaced by the actual issue number.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
