### PR TITLE
[hotfix] Fix wrong params in flink batch template

### DIFF
--- a/config/flink.batch.conf.template
+++ b/config/flink.batch.conf.template
@@ -26,9 +26,10 @@ env {
 
 source {
   # This is a example input plugin **only for test and demonstrate the feature input plugin**
-  FileSource{
-    file.path = "hdfs://localhost:9000/output/text"
-    source_format = "text"
+  FileSource {
+    path = "hdfs://localhost:9000/output/text"
+    format.type = "text"
+    schema = "string"
     result_table_name = "test"
   }
 


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[SeaTunnel #XXXX] [component] Title of the pull request", where *SeaTunnel #XXXX* should be replaced by the actual issue number.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

Some params in `flink.batch.conf.template` are deprecated, we need to update them.

https://github.com/apache/incubator-seatunnel/blob/dev/seatunnel-connectors/seatunnel-connector-flink-file/src/main/java/org/apache/seatunnel/flink/source/FileSource.java

### Stacktrace

```
2022-01-12 04:39:40,911 ERROR org.apache.seatunnel.Seatunnel  - Plugin[org.apache.seatunnel.flink.source.FileSource] contains invalid config, error: please specify [path] as non-empty 
```

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
